### PR TITLE
Use Bluebird promises, add .once to connection and channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ function connect(url, options) {
       createChannel: createChannel,
       createConfirmChannel: createChannel,
       on: function () { },
+      once: function () { },
       close: function () {
         return Bluebird.resolve();
       }

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
 "use strict";
-
+var Bluebird = require('bluebird');
 var exchanges = {};
 var queues = {};
 var channel = {
   assertQueue: function (queue, qOptions) {
-    return new Promise(function (resolve) {
+    return new Bluebird(function (resolve) {
       setIfUndef(queues, queue, { messages: [], subscribers: [], options: qOptions });
       return resolve();
     });
   },
 
   assertExchange: function (exchange, type, exchOptions) {
-    return new Promise(function (resolve) {
+    return new Bluebird(function (resolve) {
       exchOptions = exchOptions || {};
       setIfUndef(exchanges, exchange, { bindings: [], options: exchOptions, type: type });
 
@@ -20,7 +20,7 @@ var channel = {
   },
 
   bindQueue: function (queue, exchange, key, args) {
-    return new Promise(function (resolve, reject) {
+    return new Bluebird(function (resolve, reject) {
       if (!exchanges[exchange])
         return reject("Bind to non-existing exchange " + exchange);
 
@@ -32,7 +32,7 @@ var channel = {
   },
 
   publish: function (exchange, routingKey, content, props) {
-    return new Promise(function (resolve, reject) {
+    return new Bluebird(function (resolve, reject) {
       if (!exchanges[exchange])
         return reject("Publish to non-existing exchange " + exchange);
 
@@ -66,23 +66,23 @@ var channel = {
   prefetch: function () { },
   on: function () { },
   close: function () {
-    return Promise.resolve();
+    return Bluebird.resolve();
   }
 };
 function createChannel() {
-  return new Promise(function (resolve) {
+  return new Bluebird(function (resolve) {
     return resolve(channel);
   });
 };
 function connect(url, options) {
-  return new Promise(function (resolve) {
+  return new Bluebird(function (resolve) {
 
     var connection = {
       createChannel: createChannel,
       createConfirmChannel: createChannel,
       on: function () { },
       close: function () {
-        return Promise.resolve();
+        return Bluebird.resolve();
       }
     };
 

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ var channel = {
   nack: function () { },
   prefetch: function () { },
   on: function () { },
+  once: function () { },
   close: function () {
     return Bluebird.resolve();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,18 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -71,12 +76,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -103,8 +108,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -119,7 +124,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -167,7 +172,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -182,7 +187,7 @@
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqplib-mock",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Mock library for amqplib with promise and callback api support.",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "homepage": "https://github.com/jbactad/amqplib-mock#readme",
   "devDependencies": {
     "mocha": "^4.1.0"
+  },
+  "dependencies": {
+    "bluebird": "^3.5.1"
   }
 }


### PR DESCRIPTION
Would like to see support for Bluebird promises. 

Bluebird is compatible with native Promises, this should not have any impact on existing usecases.

I've also added .once to connection and channel